### PR TITLE
Not using scaffoldEthProvider

### DIFF
--- a/packages/react-app/src/App.jsx
+++ b/packages/react-app/src/App.jsx
@@ -110,7 +110,7 @@ if (DEBUG) console.log("📡 Connecting to Mainnet Ethereum");
 //
 // attempt to connect to our own scaffold eth rpc and if that fails fall back to infura...
 // Using StaticJsonRpcProvider as the chainId won't change see https://github.com/ethers-io/ethers.js/issues/901
-const scaffoldEthProvider = new StaticJsonRpcProvider("https://rpc.scaffoldeth.io:48544");
+const scaffoldEthProvider = undefined; //new StaticJsonRpcProvider("https://rpc.scaffoldeth.io:48544");
 const mainnetInfura = new StaticJsonRpcProvider("https://mainnet.infura.io/v3/" + INFURA_ID);
 // ( ⚠️ Getting "failed to meet quorum" errors? Check your INFURA_I
 


### PR DESCRIPTION
at=error code=H10 desc="App crashed" method=GET path="/" host=nft-rarible.herokuapp.com request_id=88a467b4-ff04-44ab-9315-7b75666b8b8a fwd="176.113.72.126" dyno= connect= service= status=503 bytes= protocol=https